### PR TITLE
feat: use lib@12.0.0 (android@6.4.10)

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,9 +1,9 @@
 buildscript {
     ext {
         buildToolsVersion = "35.0.0"
-        minSdkVersion = 24
+        minSdkVersion = 26
         compileSdkVersion = 35
-        targetSdkVersion = 34
+        targetSdkVersion = 35
         ndkVersion = "27.1.12297006"
         kotlinVersion = "2.0.21"
     }

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1499,7 +1499,7 @@ PODS:
     - React-logger (= 0.77.3)
     - React-perflogger (= 0.77.3)
     - React-utils (= 0.77.3)
-  - RNZoomUs (11.0.0):
+  - RNZoomUs (12.0.0):
     - React
     - ZoomSDK (= 6.1.0.16235)
   - SocketRocket (0.7.1)
@@ -1785,7 +1785,7 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: 31015410a4a53b9fd0a908ad4d6e3e2b9a25086a
   ReactCodegen: eac5d74d85dff515b48a5c36f154bc4128f217e6
   ReactCommon: bf4612cba0fa356b529385029f470d5529dddde4
-  RNZoomUs: 7612723bde6baacff6ec2cc80a380d1739242617
+  RNZoomUs: 6157c62b632819d264a30cde201d1b948f0a96ef
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Yoga: 92f3bb322c40a86b7233b815854730442e01b8c4
   ZoomSDK: eb94b18ac66afbee04c30c538c392f884aa04914

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "react": "18.3.1",
     "react-native": "0.77.3",
     "react-native-url-polyfill": "2.0.0",
-    "react-native-zoom-us": "11.0.0"
+    "react-native-zoom-us": "12.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3282,7 +3282,7 @@ __metadata:
     react: 18.3.1
     react-native: 0.77.3
     react-native-url-polyfill: 2.0.0
-    react-native-zoom-us: 11.0.0
+    react-native-zoom-us: 12.0.0
     react-test-renderer: 18.3.1
     ts-node: 10.9.2
     typescript: 5.0.4
@@ -8185,16 +8185,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-zoom-us@npm:11.0.0":
-  version: 11.0.0
-  resolution: "react-native-zoom-us@npm:11.0.0"
+"react-native-zoom-us@npm:12.0.0":
+  version: 12.0.0
+  resolution: "react-native-zoom-us@npm:12.0.0"
   dependencies:
     color: ^3.2.1
     invariant: ^2.2.4
   peerDependencies:
     react: ">=16.8.0"
     react-native: ">0.60.0"
-  checksum: 9b869421d267cabded8926c84a4782e31c13277b817d019d5790e1b7dc396798b9a54dc07e2a75dae41ae1d1e5c819cb112f3a8c4913a05d346a3779cab9c451
+  checksum: ab328fa430ef6bf92456eb7ca1e832e7cf7918f4d795a5fcfaaa46ab7fe87a3c53de9f94046fe470f0cf700fd7f6f785538b2fb5394cf744fddfb23b8ce5a0a2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Uses android 6.4.10 official Meeting SDK lib.

Test: See https://github.com/mieszko4/react-native-zoom-us/pull/391